### PR TITLE
terraform cloud の導入

### DIFF
--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,0 +1,37 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore transient lock info files created by terraform apply
+.terraform.tfstate.lock.info
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/infra/aws/environment/prod/.terraform.lock.hcl
+++ b/infra/aws/environment/prod/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.56.1"
+  constraints = "5.56.1"
+  hashes = [
+    "h1:3c0jJCaLRgXrOZoGMAOjH+omtHUo96AkukUF4/h9gaE=",
+    "zh:0fff674596251d3f46b5a9e242220871d6c634f7cf69f2741d1c3c8f4baa708c",
+    "zh:1495d0f71bbd849ad286e7afa9d531a45217e6af7e3d165a447809dab364bd9b",
+    "zh:3eab136bd5b6c58a99f5cb588220819c70061b48da98f2b40061ebabfcbe1957",
+    "zh:3faa780ae84db4751d32ce3e7c4797711c9b5c537b67884037f0951a2f93c1ee",
+    "zh:47455bd243986893cc79f3d884633961244faeeef678fd64a37fcc77f3dabe24",
+    "zh:4a26df74f018ea25f3b543e9bc9d5763c7adc0cec647fc1cb1acec47cc331953",
+    "zh:592cebca964f297f569dc86e99789bfcc301904a9c26cd7294dab99e106acf59",
+    "zh:75d5ed50f1f56c484f7fcb1bd1c4ad33e2679ed249cc8db05e561233f8f5781f",
+    "zh:7ec8cce722a91ba141a3b2db0e833acc3be91e4eec6abb41f012bc9d641ca24e",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:cba68f518f794e695b0448be4ff90906a7817f65ca5e4d987720e37fbeea7c90",
+    "zh:e29712ab48d6527253ae4aef3851bd8e831b7b0bb57b5097bef16cbb69af6e85",
+    "zh:ef34bd8ff4e1fb8cc222b78217df917d4833361ea514465e7dae9122a7c7cf7a",
+    "zh:fece9ac372653ab3195630cc9d817ad0f81cce1d2880bec03ffc624591f3702b",
+    "zh:ffd1c3b3e4fa447dd2a78f6696d0dac969cb2996d640e3efbf2a96c49892d298",
+  ]
+}

--- a/infra/aws/environment/prod/main.tf
+++ b/infra/aws/environment/prod/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  cloud {
+    organization = "matazou_organization"
+
+    workspaces {
+      name = "aws"
+    }
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.56.1"
+    }
+  }
+}
+
+provider "aws" {
+  region = "ap-northeast-1"
+}

--- a/infra/aws/trust/.terraform.lock.hcl
+++ b/infra/aws/trust/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.56.1"
+  constraints = "5.56.1"
+  hashes = [
+    "h1:3c0jJCaLRgXrOZoGMAOjH+omtHUo96AkukUF4/h9gaE=",
+    "zh:0fff674596251d3f46b5a9e242220871d6c634f7cf69f2741d1c3c8f4baa708c",
+    "zh:1495d0f71bbd849ad286e7afa9d531a45217e6af7e3d165a447809dab364bd9b",
+    "zh:3eab136bd5b6c58a99f5cb588220819c70061b48da98f2b40061ebabfcbe1957",
+    "zh:3faa780ae84db4751d32ce3e7c4797711c9b5c537b67884037f0951a2f93c1ee",
+    "zh:47455bd243986893cc79f3d884633961244faeeef678fd64a37fcc77f3dabe24",
+    "zh:4a26df74f018ea25f3b543e9bc9d5763c7adc0cec647fc1cb1acec47cc331953",
+    "zh:592cebca964f297f569dc86e99789bfcc301904a9c26cd7294dab99e106acf59",
+    "zh:75d5ed50f1f56c484f7fcb1bd1c4ad33e2679ed249cc8db05e561233f8f5781f",
+    "zh:7ec8cce722a91ba141a3b2db0e833acc3be91e4eec6abb41f012bc9d641ca24e",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:cba68f518f794e695b0448be4ff90906a7817f65ca5e4d987720e37fbeea7c90",
+    "zh:e29712ab48d6527253ae4aef3851bd8e831b7b0bb57b5097bef16cbb69af6e85",
+    "zh:ef34bd8ff4e1fb8cc222b78217df917d4833361ea514465e7dae9122a7c7cf7a",
+    "zh:fece9ac372653ab3195630cc9d817ad0f81cce1d2880bec03ffc624591f3702b",
+    "zh:ffd1c3b3e4fa447dd2a78f6696d0dac969cb2996d640e3efbf2a96c49892d298",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "4.0.6"
+  hashes = [
+    "h1:dYSb3V94K5dDMtrBRLPzBpkMTPn+3cXZ/kIJdtFL+2M=",
+    "zh:10de0d8af02f2e578101688fd334da3849f56ea91b0d9bd5b1f7a243417fdda8",
+    "zh:37fc01f8b2bc9d5b055dc3e78bfd1beb7c42cfb776a4c81106e19c8911366297",
+    "zh:4578ca03d1dd0b7f572d96bd03f744be24c726bfd282173d54b100fd221608bb",
+    "zh:6c475491d1250050765a91a493ef330adc24689e8837a0f07da5a0e1269e11c1",
+    "zh:81bde94d53cdababa5b376bbc6947668be4c45ab655de7aa2e8e4736dfd52509",
+    "zh:abdce260840b7b050c4e401d4f75c7a199fafe58a8b213947a258f75ac18b3e8",
+    "zh:b754cebfc5184873840f16a642a7c9ef78c34dc246a8ae29e056c79939963c7a",
+    "zh:c928b66086078f9917aef0eec15982f2e337914c5c4dbc31dd4741403db7eb18",
+    "zh:cded27bee5f24de6f2ee0cfd1df46a7f88e84aaffc2ecbf3ff7094160f193d50",
+    "zh:d65eb3867e8f69aaf1b8bb53bd637c99c6b649ba3db16ded50fa9a01076d1a27",
+    "zh:ecb0c8b528c7a619fa71852bb3fb5c151d47576c5aab2bf3af4db52588722eeb",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infra/aws/trust/README.md
+++ b/infra/aws/trust/README.md
@@ -1,0 +1,57 @@
+## 概要
+
+この terraform ファイルは、任意の AWS アカウントのリソースを terraform cloud を使用して管理するために必要な IAM 関連のリソースを作成するためのものです。
+
+## 手順
+
+> [!NOTE]
+> リソース管理を行いたい AWS アカウントへ IAM リソースの作成権限を持つロールにて、AWS Identity Center による SSO ができることが前提です
+
+terraform cloud へのワークスペースの作成方法は以下の記事を参考にしてください。
+
+https://zenn.dev/sikmi_tech/articles/9f302b95105f50#terraform-cloud-%E4%B8%8A%E3%81%AB%E3%83%AF%E3%83%BC%E3%82%AF%E3%82%B9%E3%83%9A%E3%83%BC%E3%82%B9%E3%82%92%E4%BD%9C%E6%88%90
+
+### 1. AWS リソースの作成
+
+terraform.tfvars.example ファイルを以下のコマンドでコピーして、ファイル内の内容を適宜修正してください。
+
+```sh
+cp terraform.tfvars.example terraform.tefvars
+```
+
+ローカルにて、aws sso コマンドにてログインを行います。
+
+```sh
+aws sso login --profile=<your profile>
+export AWS_PROFILE=<your profile>
+```
+
+terraform コマンドにて、リソースを作成します。
+
+```sh
+terraform apply
+```
+
+下記のように、role_arn が出力されるので、手元に控えておいてください。手順 2 で必要になります。
+
+```sh
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+role_arn = "arn:aws:iam::xxxxxxx:role/terraform-cloud"
+```
+
+### 2. terraform cloud に環境変数を設定
+
+作成したワークスペースの Variables に以下の環境変数を設定します。
+
+> [!NOTE]
+> 環境変数は Environment Variables で作成すること!
+
+| 環境変数名            | 値                                  |
+| --------------------- | ----------------------------------- |
+| TFC_AWS_PROVIDER_AUTH | true                                |
+| TFC_AWS_RUN_ROLE_ARN  | 手元に控えておいた IAM ロールの ARN |
+
+参考: https://zenn.dev/sikmi_tech/articles/9f302b95105f50#terraform-cloud-%E3%81%AB%E7%92%B0%E5%A2%83%E5%A4%89%E6%95%B0%E3%82%92%E8%A8%AD%E5%AE%9A%E3%81%99%E3%82%8B

--- a/infra/aws/trust/README.md
+++ b/infra/aws/trust/README.md
@@ -16,7 +16,7 @@ https://zenn.dev/sikmi_tech/articles/9f302b95105f50#terraform-cloud-%E4%B8%8A%E3
 terraform.tfvars.example ファイルを以下のコマンドでコピーして、ファイル内の内容を適宜修正してください。
 
 ```sh
-cp terraform.tfvars.example terraform.tefvars
+cp terraform.tfvars.example terraform.tfvars
 ```
 
 ローカルにて、aws sso コマンドにてログインを行います。
@@ -29,6 +29,7 @@ export AWS_PROFILE=<your profile>
 terraform コマンドにて、リソースを作成します。
 
 ```sh
+terraform init
 terraform apply
 ```
 
@@ -55,3 +56,61 @@ role_arn = "arn:aws:iam::xxxxxxx:role/terraform-cloud"
 | TFC_AWS_RUN_ROLE_ARN  | 手元に控えておいた IAM ロールの ARN |
 
 参考: https://zenn.dev/sikmi_tech/articles/9f302b95105f50#terraform-cloud-%E3%81%AB%E7%92%B0%E5%A2%83%E5%A4%89%E6%95%B0%E3%82%92%E8%A8%AD%E5%AE%9A%E3%81%99%E3%82%8B
+
+### 3. 動作確認
+
+最後に、terraform cloud によるリソース管理が期待通りに動くかを確認します。
+
+下記のコマンドを実施して、terraform cloud との認証を行います。
+
+```sh
+terraform login
+```
+
+> [!IMPORTANT]
+> ログイン時、API キーを払い出す必要がありますが、有効期限は 1 日と短くしてください。(できれば、動作確認後に API キーを削除してください)
+>
+> 実際のリソース管理は、Github Application を利用した CI/CD によるリソース管理を想定しているためです。
+
+認証に完了後、`aws/environment` 配下に任意のディクレトリを配置して、main.tf ファイルを作成します。
+
+```sh
+# イメージ
+├── environment
+│   └── prod
+│       └── main.tf
+```
+
+main.tf に以下の内容を設定してください。また、コメントされている 2 箇所に適当な値を設定してください。
+
+```hcl:main.tf
+terraform {
+  cloud {
+    # terraform cloud の組織名を設定してください
+    organization = "xxxxxx"
+
+    # terraform cloud のワークスペース名
+    workspaces {
+      name = "xxxxxx"
+    }
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.56.1"
+    }
+  }
+}
+
+provider "aws" {
+  region = "ap-northeast-1"
+}
+```
+
+最後に、terraform apply コマンドを実行して、エラーが出なければ動作確認は完了です!
+
+```sh
+terraform init
+terraform apply
+```

--- a/infra/aws/trust/main.tf
+++ b/infra/aws/trust/main.tf
@@ -1,0 +1,73 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.56.1"
+    }
+  }
+}
+
+provider "aws" {}
+
+data "aws_partition" "current" {}
+
+# TLS 証明書を取得するためのデータソースを定義
+data "tls_certificate" "terraform_cloud" {
+  url = format("https://%s", var.terraform_cloud_host)
+}
+
+# Terraform Cloud 用の OpenID Connect プロバイダを定義
+resource "aws_iam_openid_connect_provider" "terraform_cloud" {
+  url = data.tls_certificate.terraform_cloud.url
+  # OpenID Connect audience
+  client_id_list  = ["aws.workload.identity"]
+  thumbprint_list = [data.tls_certificate.terraform_cloud.certificates[0].sha1_fingerprint]
+}
+
+# 信頼ポリシー
+data "aws_iam_policy_document" "terraform_assume_role_policy" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.terraform_cloud.arn]
+    }
+
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "${var.terraform_cloud_host}:aud"
+
+      values = [
+        # OpenID Connect audience
+        one(aws_iam_openid_connect_provider.terraform_cloud.client_id_list)
+      ]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "${var.terraform_cloud_host}:sub"
+
+      values = [
+        format("organization:%s:project:%s:workspace:%s:run_phase:%s",
+          var.terraform_cloud_organization,
+          var.terraform_cloud_project,
+          var.terraform_cloud_workspace,
+          var.terraform_cloud_run_phase
+        ),
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "terraform_cloud" {
+  name               = "terraform-cloud"
+  assume_role_policy = data.aws_iam_policy_document.terraform_assume_role_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "terraform_policy_attachment" {
+  role       = aws_iam_role.terraform_cloud.name
+  policy_arn = format("arn:%s:iam::aws:policy/AdministratorAccess", data.aws_partition.current.partition)
+}

--- a/infra/aws/trust/outputs.tf
+++ b/infra/aws/trust/outputs.tf
@@ -1,0 +1,4 @@
+output "role_arn" {
+  description = "Terraform Cloud の環境変数へ登録するのに必要"
+  value       = aws_iam_role.terraform_cloud.arn
+}

--- a/infra/aws/trust/terraform.tfvars.example
+++ b/infra/aws/trust/terraform.tfvars.example
@@ -1,0 +1,3 @@
+terraform_cloud_workspace    = "terraform cloud へ作成したワークスペース名"
+terraform_cloud_project      = "ワークスペースが所属するプロジェクト名"
+terraform_cloud_organization = "ワークスペースが所属する組織名"

--- a/infra/aws/trust/variables.tf
+++ b/infra/aws/trust/variables.tf
@@ -1,0 +1,28 @@
+variable "terraform_cloud_host" {
+  type        = string
+  description = "Terraform Cloud のホスト名"
+  default     = "app.terraform.io"
+}
+
+variable "terraform_cloud_organization" {
+  type        = string
+  description = "Terraform Cloud の組織名"
+}
+
+variable "terraform_cloud_project" {
+  type        = string
+  description = "Terraform Cloud のプロジェクト名"
+  default     = "*"
+}
+
+variable "terraform_cloud_workspace" {
+  type        = string
+  description = "Terraform Cloud のワークスペース名"
+  default     = "*"
+}
+
+variable "terraform_cloud_run_phase" {
+  type        = string
+  description = "Terraform Cloud の実行フェーズ"
+  default     = "*"
+}


### PR DESCRIPTION
This pull request includes several changes to the Terraform configuration files to improve infrastructure management and add necessary configurations for Terraform Cloud. The most important changes include updating the `.gitignore` file, adding lock files, and configuring provider and workspace settings.

### Infrastructure Management

* [`infra/.gitignore`](diffhunk://#diff-9a136429a515fc729e6af87248b9287225a07477f6523e900abafb6a76943c6eR1-R37): Added patterns to ignore Terraform state files, crash logs, and other sensitive files. This helps keep the repository clean and secure.

### Provider and Workspace Configuration

* [`infra/aws/environment/prod/main.tf`](diffhunk://#diff-3d27f47f8692e797b7ecd720f53a6bdd8236ca2392d8f8a08579e961743e4df7R1-R20): Configured the Terraform Cloud organization and workspace, and specified the AWS provider version.
* [`infra/aws/trust/main.tf`](diffhunk://#diff-8bd7dd5c0a180b345304f723cf5745725d3f1ca357dc1a184e11d2f11d599a3eR1-R73): Defined the necessary IAM roles and policies for Terraform Cloud to manage AWS resources, including OpenID Connect provider and trust policy.

### Lock Files

* [`infra/aws/environment/prod/.terraform.lock.hcl`](diffhunk://#diff-fb25a5869ece083d8e6fc98f21015b957c911c730e6628bc426de4f9deb6fdc7R1-R25): Added a lock file to ensure consistent provider versions across environments.
* [`infra/aws/trust/.terraform.lock.hcl`](diffhunk://#diff-b8ede8efbe64bc9fee783b119975613a5d184836dda38ec210e169116106af5cR1-R44): Added a lock file for the `trust` environment to ensure consistent provider versions.

### Documentation

* [`infra/aws/trust/README.md`](diffhunk://#diff-1ba93857f9448ce5a9d0c5860c5fd9657c94e13c30f4ec90817dc7254b060e0fR1-R115): Added a comprehensive README file detailing the setup and configuration steps for managing AWS resources using Terraform Cloud.