### PR TITLE
ACM で証明書を発行して、ALM の リスナ-(443 port)にアタッチ

### DIFF
--- a/infra/aws/environment/prod/acm.tf
+++ b/infra/aws/environment/prod/acm.tf
@@ -1,0 +1,15 @@
+resource "aws_acm_certificate" "cert" {
+  domain_name               = "zoutrendy.site"
+  subject_alternative_names = ["*.zoutrendy.site"]
+
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate_validation" "cert" {
+  certificate_arn         = aws_acm_certificate.cert.arn
+  validation_record_fqdns = [for record in aws_route53_record.acm_main : record.fqdn]
+}

--- a/infra/aws/environment/prod/ec2.tf
+++ b/infra/aws/environment/prod/ec2.tf
@@ -48,22 +48,23 @@ resource "aws_lb" "primary" {
 ####################
 # Listener
 ####################
-# TODO: 443 port を開ける際、ACM の証明書が必要なため、一旦コメントアウト
-# resource "aws_lb_listener" "allow_tls" {
-#   load_balancer_arn = aws_lb.primary.arn
+resource "aws_lb_listener" "allow_tls" {
+  load_balancer_arn = aws_lb.primary.arn
 
-#   protocol = "HTTPS"
-#   port     = 443
+  protocol = "HTTPS"
+  port     = 443
 
-#   default_action {
-#     type             = "forward"
-#     target_group_arn = aws_alb_target_group.send_to_fargate.arn
-#   }
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_alb_target_group.send_to_fargate.arn
+  }
 
-#   tags = {
-#     Name = "allowTLS"
-#   }
-# }
+  certificate_arn = aws_acm_certificate.cert.arn
+
+  tags = {
+    Name = "allowTLS"
+  }
+}
 
 ####################
 # Target Group

--- a/infra/aws/environment/prod/route53.tf
+++ b/infra/aws/environment/prod/route53.tf
@@ -2,3 +2,20 @@ resource "aws_route53_zone" "primary" {
   name    = "zoutrendy.site"
   comment = "A zone for the zoutrendy.site domain"
 }
+
+resource "aws_route53_record" "acm_main" {
+  for_each = {
+    for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = aws_route53_zone.primary.zone_id
+}


### PR DESCRIPTION
This pull request includes changes to set up and validate a new SSL certificate for the `zoutrendy.site` domain and enable HTTPS on the load balancer. The most important changes include adding an ACM certificate resource, creating a Route 53 record for domain validation, and updating the load balancer listener to use the new certificate.

Certificate setup and validation:

* [`infra/aws/environment/prod/acm.tf`](diffhunk://#diff-44339bb959de93a95b243c8d3c3724f316ab94d4471d1bb2c5c3394dfd39d3aeR1-R15): Added a new `aws_acm_certificate` resource for `zoutrendy.site` and a corresponding `aws_acm_certificate_validation` resource to handle DNS validation.
* [`infra/aws/environment/prod/route53.tf`](diffhunk://#diff-4e948f0b0c8dc888d68affc6688f293398d7ed381fe1763468edb2de4fa9515eR5-R21): Added a new `aws_route53_record` resource to create DNS records required for ACM certificate validation.

Load balancer configuration:

* [`infra/aws/environment/prod/ec2.tf`](diffhunk://#diff-07965d907ca6300ff2f589a70af323f0a0b1a8057749fcbfa4a4e1b2f6b8e362L51-R67): Updated the `aws_lb_listener` resource to enable HTTPS on port 443 using the new ACM certificate.