### PR TITLE
fix

### DIFF
--- a/infra/aws/environment/prod/iam.tf
+++ b/infra/aws/environment/prod/iam.tf
@@ -29,6 +29,8 @@ data "aws_iam_policy_document" "ecs_task_execution" {
       "logs:CreateLogStream",
       " logs:PutLogEvents",
     ]
+
+    resources = ["*"]
   }
 }
 


### PR DESCRIPTION
This pull request includes a small change to the `infra/aws/environment/prod/iam.tf` file. The change adds a `resources` attribute to the `aws_iam_policy_document` for ECS task execution.

* [`infra/aws/environment/prod/iam.tf`](diffhunk://#diff-2055042d63655d96d023f558962c3074e4b44ae867b54c4cb0deafd3d338553cR32-R33): Added `resources = ["*"]` to the `aws_iam_policy_document` for ECS task execution.