### PR TITLE
next.js 用の ecspresso ファイルを追加

### DIFF
--- a/infra/aws/environment/prod/.terraformignore
+++ b/infra/aws/environment/prod/.terraformignore
@@ -1,1 +1,2 @@
 architecture.drawio.svg
+/ecspresso/**/*

--- a/infra/aws/environment/prod/ecspresso/nextjs/ecs-service-def.jsonnet
+++ b/infra/aws/environment/prod/ecspresso/nextjs/ecs-service-def.jsonnet
@@ -1,0 +1,52 @@
+{
+  capacityProviderStrategy: [
+    {
+      base: 1,
+      capacityProvider: 'FARGATE_SPOT',
+      weight: 100,
+    },
+  ],
+  deploymentConfiguration: {
+    alarms: {
+      enable: false,
+      rollback: false,
+    },
+    deploymentCircuitBreaker: {
+      enable: true,
+      rollback: true,
+    },
+    maximumPercent: 200,
+    minimumHealthyPercent: 100,
+  },
+  deploymentController: {
+    type: 'ECS',
+  },
+  desiredCount: 1,
+  enableECSManagedTags: true,
+  enableExecuteCommand: false,
+  healthCheckGracePeriodSeconds: 0,
+  launchType: '',
+  loadBalancers: [
+    {
+      containerName: 'next',
+      containerPort: 3000,
+      targetGroupArn: "{{ tfstate `aws_alb_target_group.send_to_nextjs.arn` }}",
+    },
+  ],
+  networkConfiguration: {
+    awsvpcConfiguration: {
+      assignPublicIp: 'ENABLED',
+      securityGroups: [
+        "{{ tfstate `aws_security_group.allow_traffic_from_alb.id` }}",
+      ],
+      subnets: [
+        "{{ tfstate `aws_subnet.public_app_primary.id` }}",
+        "{{ tfstate `aws_subnet.public_app_secondary.id` }}",
+      ],
+    },
+  },
+  platformFamily: 'Linux',
+  platformVersion: 'LATEST',
+  propagateTags: 'NONE',
+  schedulingStrategy: 'REPLICA',
+}

--- a/infra/aws/environment/prod/ecspresso/nextjs/ecs-task-def.jsonnet
+++ b/infra/aws/environment/prod/ecspresso/nextjs/ecs-task-def.jsonnet
@@ -1,0 +1,44 @@
+{
+  containerDefinitions: [
+    {
+      cpu: 0,
+      essential: true,
+      image: "{{ tfstate `aws_ecr_repository.app_next.repository_url` }}:proto2",
+      logConfiguration: {
+        logDriver: 'awslogs',
+        options: {
+          'awslogs-create-group': 'true',
+          'awslogs-group': '/ecs/next-app',
+          'awslogs-region': 'ap-northeast-1',
+          'awslogs-stream-prefix': 'ecs',
+          'max-buffer-size': '25m',
+          mode: 'non-blocking',
+        },
+      },
+      name: 'next',
+      portMappings: [
+        {
+          appProtocol: 'http',
+          containerPort: 3000,
+          hostPort: 3000,
+          name: 'next-3000-tcp',
+          protocol: 'tcp',
+        },
+      ],
+    },
+  ],
+  cpu: '1024',
+  executionRoleArn: "{{ tfstate `aws_iam_role.ecs_task_execution.arn` }}",
+  family: 'next-app',
+  ipcMode: '',
+  memory: '2048',
+  networkMode: 'awsvpc',
+  pidMode: '',
+  requiresCompatibilities: [
+    'FARGATE',
+  ],
+  runtimePlatform: {
+    cpuArchitecture: 'X86_64',
+    operatingSystemFamily: 'LINUX',
+  },
+}

--- a/infra/aws/environment/prod/ecspresso/nextjs/ecspresso.jsonnet
+++ b/infra/aws/environment/prod/ecspresso/nextjs/ecspresso.jsonnet
@@ -1,0 +1,16 @@
+{
+  region: 'ap-northeast-1',
+  cluster: 'next-rails',
+  service: 'nextjs',
+  service_definition: 'ecs-service-def.jsonnet',
+  task_definition: 'ecs-task-def.jsonnet',
+  timeout: '10m0s',
+  plugins: [
+    {
+      name: 'tfstate',
+      config: {
+        url: 'remote://app.terraform.io/matazou_organization/aws'
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This pull request includes several changes to the infrastructure configuration for the production environment, primarily focusing on the ECS service and task definitions for the Next.js application. The most important changes include the addition of `ecspresso` configuration files and updates to the `.terraformignore` file.

### ECS Configuration:

* [`infra/aws/environment/prod/ecspresso/nextjs/ecs-service-def.jsonnet`](diffhunk://#diff-4c0d341a23b41d0cde492bf729be48c503b99cec4eb1f3ac212a641be4a4ed44R1-R52): Added ECS service definition with capacity provider strategy, deployment configuration, load balancers, and network configuration.
* [`infra/aws/environment/prod/ecspresso/nextjs/ecs-task-def.jsonnet`](diffhunk://#diff-ecb78d0197a25f368a7dea7f56851dcbe00615cc9fbd8b8c2ea1047b90bd1eb4R1-R44): Added ECS task definition with container definitions, log configuration, port mappings, and runtime platform settings.
* [`infra/aws/environment/prod/ecspresso/nextjs/ecspresso.jsonnet`](diffhunk://#diff-05c305b73b6cc7f3abc704b1269cdf355fadf04689bb7a77af263af7323fc4e8R1-R16): Added `ecspresso` configuration file specifying the region, cluster, service, service definition, task definition, and plugins.

### Terraform Configuration:

* [`infra/aws/environment/prod/.terraformignore`](diffhunk://#diff-50d8775a58273c7708907b65a9eb16c306bd8350446a1d36afe5bb2bf1061cb3R2): Updated to include the `ecspresso` directory.